### PR TITLE
chore: update Unico Capture SDK version to 4.4.1

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -42,5 +42,5 @@ android {
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
     implementation 'androidx.appcompat:appcompat:1.3.1'
-    implementation "io.unico:capture:4.4.0"
+    implementation "io.unico:capture:4.4.1"
 }


### PR DESCRIPTION
The Unico Capture SDK version has been updated to 4.4.1

Why?
> To ensure that we have the latest features, bug fixes, and improvements provided by the Unico Capture SDK, it is necessary to update the SDK version to 4.4.1.

Changes
> Updated the Unico Capture SDK to version 4.4.1.

### How to test
> Ensure that the application still builds successfully after the SDK update.
> Build and run the example application.
