### PR TITLE
chore(android): update SDK dependency to version 5.0.0

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -42,5 +42,5 @@ android {
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
     implementation 'androidx.appcompat:appcompat:1.3.1'
-    implementation "io.unico:capture:5.0.0-beta2"
+    implementation "io.unico:capture:5.0.0"
 }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -42,5 +42,5 @@ android {
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
     implementation 'androidx.appcompat:appcompat:1.3.1'
-    implementation "io.unico:capture:4.4.1"
+    implementation "io.unico:capture:5.0.0-beta2"
 }


### PR DESCRIPTION
Update Android Unico Capture SDK dependency to version 5.0.0

The Unico Capture SDK dependency has been updated to version 5.0.0. This update may include new features, bug fixes, and performance improvements.