### PR TITLE
chore: update native ios dependency to version 2.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 4.2.0
+
+- Atualização da sdk nativa iOS para `2.6.0` [release notes](https://developers.unico.io/docs/check/SDK/iOS/release-notesiOSSDK)
+
 ## 4.1.0
 
 ``Publicado: 24/10/2023``

--- a/ios/unico_check.podspec
+++ b/ios/unico_check.podspec
@@ -4,7 +4,7 @@
 #
 Pod::Spec.new do |s|
   s.name             = 'unico_check'
-  s.version          = '2.0.4'
+  s.version          = '2.0.5'
   s.summary          = 'Esta biblioteca visa implementar a tecnologia Unico.'
   s.description      = <<-DESC
 Esta biblioteca visa implementar a tecnologia Unico.
@@ -15,7 +15,7 @@ Esta biblioteca visa implementar a tecnologia Unico.
   s.source           = { :path => '.' }
   s.source_files = 'Classes/**/*'
   s.dependency 'Flutter'
-  s.dependency  'unicocheck-ios', '~> 2.4.0'
+  s.dependency  'unicocheck-ios', '~> 2.6.0'
   s.static_framework = false
   s.platform = :ios, '11.0'
 


### PR DESCRIPTION
### Why?
> Keep native dependency updated

### Changes
> Update iOS native version to `2.6.0` in `.podspec`;
> Bump `.podspec` version to `2.0.5`
> Update `CHANGELOG` but the version number and the date might change before the final deploy

### How to test
> Run an iOS flutter PoC

### Preview
N/A

### Issues
N/A
