### PR TITLE
release: 4.7.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Pré-requisito minSdkVersion : 21
 
 ## IOS
 
-Pré-requisito versão 11 ou superior.
+Pré-requisito versão iOS 11 ou superior e Xcode 15 ou superior.
 
 Caso ainda não possua as permissões para o uso de câmera em seu projeto
 
@@ -19,4 +19,4 @@ Caso ainda não possua as permissões para o uso de câmera em seu projeto
 `<string>Camera usage description</string>`
 
 Para mais detalhes confira nossa documentação.
-https://developers.unico.io/guias/flutter/overview/
+https://developers.unico.io/docs/

--- a/example/README.md
+++ b/example/README.md
@@ -11,7 +11,8 @@ Pré-requisito minSdkVersion : 21
 
 ## IOS
 
-Pré-requisito versão 9 ou superior.
+Pré-requisito versão iOS 11 ou superior e Xcode 15 ou superior.
+
 
 1 - Caso ainda não possua as permissões para o uso de câmera em seu projeto
 

--- a/example/ios/Flutter/AppFrameworkInfo.plist
+++ b/example/ios/Flutter/AppFrameworkInfo.plist
@@ -21,6 +21,6 @@
   <key>CFBundleVersion</key>
   <string>1.0</string>
   <key>MinimumOSVersion</key>
-  <string>9.0</string>
+  <string>11.0</string>
 </dict>
 </plist>

--- a/example/ios/Podfile
+++ b/example/ios/Podfile
@@ -1,5 +1,5 @@
 # Uncomment this line to define a global platform for your project
-# platform :ios, '12.0'
+platform :ios, '11.0'
 
 # CocoaPods analytics sends network stats synchronously affecting flutter build latency.
 ENV['COCOAPODS_DISABLE_STATS'] = 'true'

--- a/example/ios/Runner.xcodeproj/project.pbxproj
+++ b/example/ios/Runner.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 51;
+	objectVersion = 54;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -156,7 +156,7 @@
 		97C146E61CF9000F007C117D /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastUpgradeCheck = 1300;
+				LastUpgradeCheck = 1430;
 				ORGANIZATIONNAME = "";
 				TargetAttributes = {
 					97C146ED1CF9000F007C117D = {

--- a/example/ios/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
+++ b/example/ios/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1300"
+   LastUpgradeVersion = "1430"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/ios/unico_check.podspec
+++ b/ios/unico_check.podspec
@@ -9,13 +9,13 @@ Pod::Spec.new do |s|
   s.description      = <<-DESC
 Esta biblioteca visa implementar a tecnologia Unico.
                        DESC
-  s.homepage         = 'https://www3.acesso.io/sdkbio'
+  s.homepage         = 'https://developers.unico.io/docs/'
   s.license          = { :file => '../LICENSE' }
   s.author           = { 'unico id tech' => 'suporte.unicocheck@unico.io' }
   s.source           = { :path => '.' }
   s.source_files = 'Classes/**/*'
   s.dependency 'Flutter'
-  s.dependency  'unicocheck-ios', '~> 2.11.0'
+  s.dependency  'unicocheck-ios', '2.12.0'
   s.static_framework = false
   s.platform = :ios, '11.0'
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: unico_check
 description: Esta biblioteca visa implementar a tecnologia unico check na plataforma flutter.
-version: 4.6.0
+version: 4.7.0
 homepage: https://github.com/acesso-io/unico_check_flutter
 
 environment:


### PR DESCRIPTION
### Why?
> update ONLY iOS dependency to version '2.12.0' with required Privacy manifest.

#### Report generated from exemple
[Runner-PrivacyReport-release-4.7.0.pdf](https://github.com/acesso-io/unico-check-flutter/files/15132388/Runner-PrivacyReport-release-4.7.0.pdf)


### Changes
> update doc's and README's links;
> update Podspec to version '2.12.0';
> update example to minimum iOS 11;
> update example to run on Xcode 15;

