### PR TITLE
feat: flutter release 4.25.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ``Publicado: 07/03/2025``
 
+- Atualização da sdk nativa android
+  para `5.31.0` [release notes](https://devcenter.unico.io/idcloud/integracao/sdk/integracao-sdks/sdk-android/release-notes#versao-5250)
 - Atualização da sdk nativa iOS
   para `2.16.10` [release notes](https://devcenter.unico.io/idcloud/integracao/sdk/integracao-sdks/sdk-ios/release-notes#versao-2164)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 4.25.0
 
-``Publicado: 07/03/2025``
+``Publicado: 13/03/2025``
 
 - Atualização da sdk nativa android
   para `5.31.0` [release notes](https://devcenter.unico.io/idcloud/integracao/sdk/integracao-sdks/sdk-android/release-notes#versao-5250)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 4.25.0
+
+``Publicado: 07/03/2025``
+
+- Atualização da sdk nativa iOS
+  para `2.16.10` [release notes](https://devcenter.unico.io/idcloud/integracao/sdk/integracao-sdks/sdk-ios/release-notes#versao-2164)
+
 ## 4.24.0
 
 ``Publicado: 27/02/2025``

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -42,5 +42,5 @@ android {
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
     implementation 'androidx.appcompat:appcompat:1.3.1'
-    implementation "io.unico:capture:5.30.1"
+    implementation "io.unico:capture:5.31.0"
 }

--- a/ios/unico_check.podspec
+++ b/ios/unico_check.podspec
@@ -15,7 +15,7 @@ Esta biblioteca visa implementar a tecnologia Unico.
   s.source           = { :path => '.' }
   s.source_files = 'Classes/**/*'
   s.dependency 'Flutter'
-  s.dependency  'unicocheck-ios', '2.16.9'
+  s.dependency  'unicocheck-ios', '2.16.10'
   s.static_framework = false
   s.platform = :ios, '11.0'
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: unico_check
 description: Esta biblioteca visa implementar a tecnologia unico check na plataforma flutter.
 version: 4.25.0
-homepage: https://github.com/acesso-io/unico_check_flutter
+homepage: https://devcenter.unico.io/idcloud/integracao/sdk/integracao-sdks/sdk-flutter
 
 environment:
   sdk: ">=2.15.0 <4.0.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: unico_check
 description: Esta biblioteca visa implementar a tecnologia unico check na plataforma flutter.
-version: 4.24.0
+version: 4.25.0
 homepage: https://github.com/acesso-io/unico_check_flutter
 
 environment:

--- a/test/src/unico/adapter/api/unico.check.camera.opener.default_test.dart
+++ b/test/src/unico/adapter/api/unico.check.camera.opener.default_test.dart
@@ -5,8 +5,6 @@ import 'package:unico_check/src/unico/adapter/api/unico.check.camera.opener.defa
 import 'package:unico_check/src/unico/domain/entities/camera_opener/camera.opener.config.entity.dart';
 import 'package:unico_check/src/unico/domain/entities/methods.channel.dart';
 import 'package:unico_check/src/unico/domain/entities/open.camera.request.dart';
-import 'package:unico_check/src/unico/domain/entities/unico.environment.dart';
-import 'package:unico_check/src/unico/domain/entities/unico.locale.types.dart';
 import 'package:unico_check/src/unico/domain/usecase/open.camera.usecase.dart';
 import 'package:unico_check/src/unico/domain/usecase/unico.callback.usecase.dart';
 import 'package:unico_check/unico_check.dart';

--- a/test/src/unico/adapter/api/unico.check.camera.opener.default_test.dart
+++ b/test/src/unico/adapter/api/unico.check.camera.opener.default_test.dart
@@ -5,6 +5,8 @@ import 'package:unico_check/src/unico/adapter/api/unico.check.camera.opener.defa
 import 'package:unico_check/src/unico/domain/entities/camera_opener/camera.opener.config.entity.dart';
 import 'package:unico_check/src/unico/domain/entities/methods.channel.dart';
 import 'package:unico_check/src/unico/domain/entities/open.camera.request.dart';
+import 'package:unico_check/src/unico/domain/entities/unico.environment.dart';
+import 'package:unico_check/src/unico/domain/entities/unico.locale.types.dart';
 import 'package:unico_check/src/unico/domain/usecase/open.camera.usecase.dart';
 import 'package:unico_check/src/unico/domain/usecase/unico.callback.usecase.dart';
 import 'package:unico_check/unico_check.dart';


### PR DESCRIPTION
### Why?
chore: update iOS version 2.16.10

### Changes
This pull request includes several updates to the `unico_check` library, primarily focused on upgrading dependencies and versioning. The most important changes are listed below:

### Dependency Updates:
* Updated `unicocheck-ios` dependency version from `2.16.9` to `2.16.10` in `ios/unico_check.podspec`.

### Versioning:
* Updated the version of the `unico_check` library from `4.24.0` to `4.25.0` in `pubspec.yaml`.

### Documentation:
* Added a new entry for version `4.25.0` in `CHANGELOG.md`, including the release date and a note about the iOS SDK update.

### Code Cleanup:
* Removed unused imports in `test/src/unico/adapter/api/unico.check.camera.opener.default_test.dart`.

### How to test
n/a

### Preview
![Captura de Tela 2025-03-07 à(s) 11 42 57](https://github.com/user-attachments/assets/89f5563c-5ea5-44ef-91c6-bd8e30dc2406)
![image](https://github.com/user-attachments/assets/3f15a2c2-e8da-476d-809b-72449e62df98)

### Issues
n/a
